### PR TITLE
Fixed compilation on ESPHome 2025.2

### DIFF
--- a/esphome-configs/slwf-08-Palakis.yaml
+++ b/esphome-configs/slwf-08-Palakis.yaml
@@ -1,17 +1,18 @@
 substitutions:
-  name: hdmi-control-palakis
+  name: "hdmi-control-palakis"
   friendly_name: "HDMI Control - palakis"
+  project_name: "SMLIGHT.SLWF-08-HDMI"
+  project_version: "1.0-Palakis"
 
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
-#  platformio_options:
-#    board_buid.f_cpu: 160000000L
   name_add_mac_suffix: true
   project:
-    name: SMLIGHT.SLWF-08-HDMI
-    version: "1.0-Palakis"
-  platform: ESP8266
+    name: "${project_name}"
+    version: "${project_version}"
+
+esp8266:
   board: esp12e
 
 wifi:

--- a/esphome-configs/slwf-08-johnboiles.yaml
+++ b/esphome-configs/slwf-08-johnboiles.yaml
@@ -1,17 +1,18 @@
 substitutions:
-  name: hdmi-control
-  friendly_name: "HDMI Control"
+  name: "hdmi-control-johnboiles"
+  friendly_name: "HDMI Control - johnboiles"
+  project_name: "SMLIGHT.SLWF-08-HDMI"
+  project_version: "1.0-Johnboiles"
 
 esphome:
   name: "${name}"
   friendly_name: "${friendly_name}"
-#  platformio_options:
-#    board_buid.f_cpu: 160000000L
   name_add_mac_suffix: true
   project:
-    name: SMLIGHT.SLWF-08-HDMI
-    version: "1.0"
-  platform: ESP8266
+    name: "${project_name}"
+    version: "${project_version}"
+
+esp8266:
   board: esp12e
 
 wifi:


### PR DESCRIPTION
ESPHome moved the platform config into its own section a while ago while still keeping the old implementation, which worked up until 2025.2, where they finally removed the old implementation completely.